### PR TITLE
install uWSGI python3 plugin, not python2

### DIFF
--- a/03-web-app/lab.md
+++ b/03-web-app/lab.md
@@ -115,7 +115,7 @@ application container server that will run our application.
 
 This role should:
  1. Install uWSGI packages; Ubuntu 18.04 packages that we'll need are named
-    `uwsgi` and `uwsgi-plugin-python`.
+    `uwsgi` and `uwsgi-plugin-python3`.
  2. Add the uWSGI configuration for AGAMA so that the application is run by user
     `agama`
  4. Ensure that uWSGI service is started (unconditionally) and enabled to start


### PR DESCRIPTION
Install python3 uWSGI plugin, not the default python2 version.

This fixes two issues caused by using python2 instead of python3:
- The emoji in the title will throw an error, since `# -*- coding: utf-8 -*-` is not specified in agama.py. This is only the case for python2, seems to be fixed in pyhon3 (UTF-8 is the default now?). The error in question:
`SyntaxError: Non-ASCII character '\xf0' in file ./agama.py on line 151`

- Flask will not be available in python2 since AGAMA dependancies specify `apt install python3-flask-sqlalchemy`, which installs it only for python3.

- Maybe more but at this point I just switched over to python3 which made things work.

