### PR TITLE
lab13: haproxy ex fix tabulation

### DIFF
--- a/13-haproxy/lab.md
+++ b/13-haproxy/lab.md
@@ -98,11 +98,11 @@ Hint:
 `--haproxy.scrape-uri="http://haproxy.example.com/haproxy?stats;csv"` is a command that you should pass to container, might be missleading as it looks like parameter. Example:
 
     - name: HAProxy exporter
-        docker_container:
+      docker_container:
         name: haproxy_exporter
         image: quay.io/prometheus/haproxy-exporter:v0.9.0
         ports:
-            - 9101:9101
+          - 9101:9101
         command: --haproxy.scrape-uri="http://haproxy.example.com/haproxy?stats;csv"
 
 ## Task 5. Add Keepalived monitoring


### PR DESCRIPTION
I had noticed that vscode was using too many tabs in markdown syntax, by the time I could commit the PR was already merged :D 
Removes 2 extra spaces from two lines